### PR TITLE
path to media should not have double slashes

### DIFF
--- a/app/code/community/Billmate/Bankpay/Model/Adminhtml/Comment.php
+++ b/app/code/community/Billmate/Bankpay/Model/Adminhtml/Comment.php
@@ -2,6 +2,6 @@
 
 class Billmate_Bankpay_Model_Adminhtml_Comment{
     public function getCommentText(){ //this method must exits. It returns the text for the comment
-        return '<img src="'.Mage::getBaseUrl(Mage_Core_Model_Store::URL_TYPE_MEDIA).'/billmate/images/billmate_bank_s.png?dyn"/>';
+        return '<img src="'.Mage::getBaseUrl(Mage_Core_Model_Store::URL_TYPE_MEDIA).'billmate/images/billmate_bank_s.png?dyn"/>';
     }
 }

--- a/app/code/community/Billmate/BillmateInvoice/Model/Adminhtml/Comment.php
+++ b/app/code/community/Billmate/BillmateInvoice/Model/Adminhtml/Comment.php
@@ -2,6 +2,6 @@
 
 class Billmate_BillmateInvoice_Model_Adminhtml_Comment{
     public function getCommentText(){ //this method must exits. It returns the text for the comment
-        return '<img src="'.Mage::getBaseUrl(Mage_Core_Model_Store::URL_TYPE_MEDIA).'/billmate/images/bm_faktura_l.png?dyn"/>';
+        return '<img src="'.Mage::getBaseUrl(Mage_Core_Model_Store::URL_TYPE_MEDIA).'billmate/images/bm_faktura_l.png?dyn"/>';
     }
 }

--- a/app/code/community/Billmate/Cardpay/Model/Adminhtml/Comment.php
+++ b/app/code/community/Billmate/Cardpay/Model/Adminhtml/Comment.php
@@ -2,6 +2,6 @@
 
 class Billmate_Cardpay_Model_Adminhtml_Comment{
     public function getCommentText(){ //this method must exits. It returns the text for the comment
-        return '<img src="'.Mage::getBaseUrl(Mage_Core_Model_Store::URL_TYPE_MEDIA)."/billmate/images/bm_kort_l.png".'"/>';
+        return '<img src="'.Mage::getBaseUrl(Mage_Core_Model_Store::URL_TYPE_MEDIA)."billmate/images/bm_kort_l.png".'"/>';
     }
 }

--- a/app/code/community/Billmate/PartPayment/Model/Adminhtml/Comment.php
+++ b/app/code/community/Billmate/PartPayment/Model/Adminhtml/Comment.php
@@ -2,6 +2,6 @@
 
 class Billmate_Partpayment_Model_Adminhtml_Comment{
     public function getCommentText(){ //this method must exits. It returns the text for the comment
-        return '<img src="'.Mage::getBaseUrl(Mage_Core_Model_Store::URL_TYPE_MEDIA).'/billmate/images/bm_delbetalning_l.png?dyn"/>';
+        return '<img src="'.Mage::getBaseUrl(Mage_Core_Model_Store::URL_TYPE_MEDIA).'billmate/images/bm_delbetalning_l.png?dyn"/>';
     }
 }


### PR DESCRIPTION
Mage_Core_Model_Store::URL_TYPE_MEDIA prints like this /media/
At the moment we get this path to media: http://siteurl/media//billmate/images/bm_kort_l.png